### PR TITLE
Updated gradle and support library versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ captures/
 
 # Intellij
 *.iml
-.idea/workspace.xml
+.idea
 
 # Keystore files
 *.jks

--- a/XYZReader/build.gradle
+++ b/XYZReader/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 apply plugin: 'com.android.application'
@@ -14,7 +14,7 @@ repositories {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 19

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,7 +18,7 @@ allprojects {
     }
 
     ext {
-        androidSupportVersion = "25.3.0"
+        androidSupportVersion = "25.3.1"
 
     }
 }


### PR DESCRIPTION
On Android Studio 2.3.1 the project doesn't compile because of an outdated Gradle version. The top level `build.gradle` file specifies a different version that the project level file. 